### PR TITLE
Feat: advance unmarshal json

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,3 +198,98 @@ example := Bhinnekaners{
   ]
 }
 ```
+
+
+### Advance JSON Unmarshal
+
+```go
+package main
+
+import (
+	"fmt"
+	"github.com/Bhinneka/goson"
+)
+
+type Slice struct {
+	FieldA int    `json:"fieldA"`
+	FieldB string `json:"fieldB"`
+	Exist  string `json:"exist"`
+}
+type Model struct {
+	ID        int     `json:"id" default:"1"`
+	Name      string  `json:"name"`
+	MustFloat float64 `json:"mustFloat"`
+	MustInt   int     `json:"mustInt"`
+	IsExist   bool    `json:"isExist"`
+	Obj       *struct {
+		N       int `json:"n"`
+		Testing struct {
+			Ss int `json:"ss"`
+		} `json:"testing"`
+	} `json:"obj"`
+	Slice []Slice `json:"slice"`
+}
+
+var data = []byte(`
+{
+	"id": "01",
+	"name": "agungdp",
+	"mustFloat": "2.23423",
+	"mustInt": 2.23423,
+	"isExist": "true",
+	"obj": {
+		"n": 2,
+		"testing": {
+			"ss": "23840923849284"
+		}
+	},
+	"slice": [
+		{
+			"fieldA": "100",
+			"fieldB": "3000",
+			"exist": true
+		},
+		{
+			"fieldA": 50000,
+			"fieldB": "123000"
+		}
+	]
+}
+`)
+
+func main() {
+	var target Model
+	goson.Unmarshal(data, &target)
+	fmt.Printf("%+v\n", target)
+}
+```
+
+<b>Value from target:</b>
+
+```json
+{
+     "id": 1,
+     "name": "agungdp",
+     "mustFloat": 2.23423,
+     "mustInt": 2,
+     "isExist": true,
+     "obj": {
+          "n": 2,
+          "testing": {
+               "ss": 23840923849284
+          }
+     },
+     "slice": [
+          {
+               "fieldA": 100,
+               "fieldB": "3000",
+               "exist": "true"
+          },
+          {
+               "fieldA": 50000,
+               "fieldB": "123000",
+               "exist": ""
+          }
+     ]
+}
+```

--- a/json_unmarshal.go
+++ b/json_unmarshal.go
@@ -1,0 +1,150 @@
+package goson
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strconv"
+	"strings"
+)
+
+var (
+	// check basic type data (integer, float, string, boolean)
+	intCheck = map[reflect.Kind]bool{
+		reflect.Int8: true, reflect.Int16: true, reflect.Int32: true, reflect.Int: true, reflect.Int64: true,
+	}
+	floatCheck = map[reflect.Kind]bool{
+		reflect.Float32: true, reflect.Float64: true,
+	}
+	stringCheck = map[reflect.Kind]bool{
+		reflect.String: true,
+	}
+	boolCheck = map[reflect.Kind]bool{
+		reflect.Bool: true,
+	}
+)
+
+// Unmarshal json string, avoid error if incompatible data type
+func Unmarshal(data []byte, target interface{}) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("panic: %v", r)
+		}
+	}()
+
+	refValue := reflect.ValueOf(target)
+	if ok := whiteListType[refValue.Kind().String()]; !ok {
+		return fmt.Errorf("invalid target type %v: accept pointer, slice, and map", refValue.Kind())
+	}
+
+	var tmp map[string]interface{}
+	err = json.Unmarshal(data, &tmp)
+	if err != nil {
+		return err
+	}
+
+	fetchDataType(refValue, tmp)
+	return
+}
+
+func fetchDataType(obj reflect.Value, source map[string]interface{}) {
+	switch obj.Kind() {
+	case reflect.Struct:
+		scan(obj, source)
+
+	case reflect.Ptr:
+		if obj.IsNil() {
+			val := obj.Interface()
+			rv := reflect.ValueOf(val)
+			val = reflect.New(rv.Type().Elem()).Interface()
+			obj.Set(reflect.ValueOf(val))
+		}
+		fetchDataType(obj.Elem(), source)
+	}
+}
+
+func scan(obj reflect.Value, data map[string]interface{}) {
+	objType := obj.Type()
+	for i := 0; i < obj.NumField(); i++ {
+		field := obj.Field(i)
+		if !field.CanSet() { // break if field cannot set a value (usually an unexported field in struct), to avoid a panic
+			return
+		}
+
+		fetchDataType(field, data)
+
+		jsonTag := objType.Field(i).Tag.Get("json")
+		if jsonTags := strings.Split(jsonTag, ","); len(jsonTags) > 0 {
+			jsonTag = jsonTags[0]
+		}
+		if jsonTag == "" {
+			jsonTag = objType.Field(i).Name
+		}
+
+		setValue(field, data[jsonTag])
+	}
+}
+
+func setValue(targetField reflect.Value, data interface{}) {
+	if data == nil || !targetField.IsValid() {
+		return
+	}
+
+	targetKind := targetField.Kind()     // targetKind is datatype from target
+	valueSource := reflect.ValueOf(data) // valueSource is datatype from json source
+
+	// switch datatype from json source
+	switch valueSource.Kind() {
+	case reflect.String:
+		str := valueSource.Interface().(string)
+		if stringCheck[targetKind] {
+			targetField.Set(valueSource)
+		} else if intCheck[targetKind] {
+			if val, err := strconv.Atoi(str); err == nil {
+				targetField.Set(reflect.ValueOf(int(val)))
+			}
+		} else if floatCheck[targetKind] {
+			if val, err := strconv.ParseFloat(str, -1); err == nil {
+				targetField.Set(reflect.ValueOf(val))
+			}
+		} else if boolCheck[targetKind] {
+			if val, err := strconv.ParseBool(str); err == nil {
+				targetField.Set(reflect.ValueOf(val))
+			}
+		}
+
+	case reflect.Float64:
+		fl := valueSource.Interface().(float64)
+		if floatCheck[targetKind] {
+			targetField.Set(valueSource)
+		} else if intCheck[targetKind] {
+			targetField.Set(reflect.ValueOf(int(fl)))
+		} else if stringCheck[targetKind] {
+			targetField.Set(reflect.ValueOf(strconv.FormatFloat(fl, 'f', -1, 64)))
+		}
+
+	case reflect.Bool:
+		if boolCheck[targetKind] {
+			targetField.Set(valueSource)
+		} else if stringCheck[targetKind] {
+			bl := valueSource.Interface().(bool)
+			targetField.Set(reflect.ValueOf(strconv.FormatBool(bl)))
+		}
+
+	case reflect.Map: // representation from struct
+		subData := valueSource.Interface().(map[string]interface{})
+		fetchDataType(targetField, subData)
+
+	case reflect.Slice:
+		if targetKind == reflect.Slice {
+			data := valueSource.Interface().([]interface{})
+			tmpSlice := reflect.MakeSlice(reflect.SliceOf(reflect.TypeOf(targetField.Interface()).Elem()), len(data), len(data))
+			for i := 0; i < tmpSlice.Len(); i++ {
+				subData := data[i].(map[string]interface{})
+				obj := tmpSlice.Index(i)
+				fetchDataType(obj, subData)
+			}
+			targetField.Set(tmpSlice)
+		}
+	}
+}

--- a/json_unmarshal.go
+++ b/json_unmarshal.go
@@ -10,6 +10,9 @@ import (
 
 var (
 	// check basic data type (integer, float, string, boolean)
+	uintCheck = map[reflect.Kind]bool{
+		reflect.Uint8: true, reflect.Uint16: true, reflect.Uint32: true, reflect.Uint: true, reflect.Uint64: true,
+	}
 	intCheck = map[reflect.Kind]bool{
 		reflect.Int8: true, reflect.Int16: true, reflect.Int32: true, reflect.Int: true, reflect.Int64: true,
 	}
@@ -110,6 +113,10 @@ func setValue(targetField reflect.Value, data interface{}) {
 			if val, err := strconv.Atoi(str); err == nil {
 				targetField.Set(reflect.ValueOf(int(val)))
 			}
+		case uintCheck[targetKind]:
+			if val, err := strconv.Atoi(str); err == nil {
+				targetField.Set(reflect.ValueOf(uint(val)))
+			}
 		case floatCheck[targetKind]:
 			if val, err := strconv.ParseFloat(str, -1); err == nil {
 				value := reflect.ValueOf(val)
@@ -134,7 +141,9 @@ func setValue(targetField reflect.Value, data interface{}) {
 			targetField.Set(valueSource)
 		case intCheck[targetKind]:
 			targetField.Set(reflect.ValueOf(int(fl)))
-		case stringCheck[targetKind], boolCheck[targetKind]:
+		case uintCheck[targetKind]:
+			targetField.Set(reflect.ValueOf(uint(fl)))
+		case stringCheck[targetKind]:
 			targetField.Set(reflect.ValueOf(strconv.FormatFloat(fl, 'f', -1, 64)))
 		case boolCheck[targetKind]:
 			if v, err := strconv.ParseBool(strconv.FormatFloat(fl, 'f', -1, 64)); err == nil {

--- a/json_unmarshal_test.go
+++ b/json_unmarshal_test.go
@@ -1,29 +1,33 @@
 package goson
 
 import (
-	"fmt"
 	"testing"
+
+	"github.com/agungdwiprasetyo/go-utils/debug"
 )
 
 func TestUnmarshal(t *testing.T) {
 	type Slice struct {
-		FieldA int    `json:"fieldA"`
-		FieldB string `json:"fieldB"`
-		Exist  string `json:"exist"`
+		FieldA int     `json:"fieldA"`
+		FieldB string  `json:"fieldB"`
+		Exist  string  `json:"exist"`
+		Test   float32 `json:"test"`
 	}
 	type Model struct {
-		ID        int     `json:"id" default:"1"`
-		Name      string  `json:"name"`
-		MustFloat float64 `json:"mustFloat"`
-		MustInt   int     `json:"mustInt"`
-		IsExist   bool    `json:"isExist"`
+		ID        int      `json:"id" default:"1"`
+		Name      string   `json:"name"`
+		MustFloat *float64 `json:"mustFloat"`
+		MustInt   int      `json:"mustInt"`
+		IsExist   *bool    `json:"isExist"`
 		Obj       *struct {
 			N       int `json:"n"`
 			Testing struct {
 				Ss int `json:"ss"`
 			} `json:"testing"`
 		} `json:"obj"`
-		Slice []Slice `json:"slice"`
+		Slice   []Slice   `json:"slice"`
+		Strings []*string `json:"str"`
+		Ints    []int     `json:"ints"`
 	}
 
 	t.Run("Testing unmarshal", func(t *testing.T) {
@@ -47,15 +51,35 @@ func TestUnmarshal(t *testing.T) {
 				  },
 				  {
 					"fieldA": 50000,
-					"fieldB": "123000"
+					"fieldB": "123000",
+					"test": 1323.123
 				  }
-				]
+				],
+				"str": ["a", true],
+				"ints": ["2", 3]
 			  }`)
 		var target Model
 		if err := Unmarshal(data, &target); err != nil {
 			t.Errorf("Unmarshal() error = %v", err)
 		}
+		if target.MustFloat == nil {
+			t.Errorf("field should not nil")
+		}
+		if target.Obj.Testing.Ss != 23840923849284 {
+			t.Errorf("value not equal")
+		}
+		if target.Slice[0].Exist != "true" {
+			t.Errorf("value not equal")
+		}
+		if *target.Strings[1] != "true" {
+			t.Errorf("value not equal")
+		}
+		if target.Ints[0] != 2 {
+			t.Errorf("value not equal")
+		}
+
 		// fmt.Println("==================================================================")
-		fmt.Printf("\n%+v\n\n", target)
+		// fmt.Printf("\n%+v\n\n", target)
+		debug.PrintJSON(target)
 	})
 }

--- a/json_unmarshal_test.go
+++ b/json_unmarshal_test.go
@@ -1,0 +1,61 @@
+package goson
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestUnmarshal(t *testing.T) {
+	type Slice struct {
+		FieldA int    `json:"fieldA"`
+		FieldB string `json:"fieldB"`
+		Exist  string `json:"exist"`
+	}
+	type Model struct {
+		ID        int     `json:"id" default:"1"`
+		Name      string  `json:"name"`
+		MustFloat float64 `json:"mustFloat"`
+		MustInt   int     `json:"mustInt"`
+		IsExist   bool    `json:"isExist"`
+		Obj       *struct {
+			N       int `json:"n"`
+			Testing struct {
+				Ss int `json:"ss"`
+			} `json:"testing"`
+		} `json:"obj"`
+		Slice []Slice `json:"slice"`
+	}
+
+	t.Run("Testing unmarshal", func(t *testing.T) {
+		data := []byte(`{
+				"id": "01",
+				"name": "agungdp",
+				"mustFloat": "2.23423",
+				"mustInt": 2.23423,
+				"isExist": "true",
+				"obj": {
+				  "n": 2,
+				  "testing": {
+					"ss": "23840923849284"
+				  }
+				},
+				"slice": [
+				  {
+					"fieldA": "100",
+					"fieldB": "3000",
+					"exist": true
+				  },
+				  {
+					"fieldA": 50000,
+					"fieldB": "123000"
+				  }
+				]
+			  }`)
+		var target Model
+		if err := Unmarshal(data, &target); err != nil {
+			t.Errorf("Unmarshal() error = %v", err)
+		}
+		// fmt.Println("==================================================================")
+		fmt.Printf("\n%+v\n\n", target)
+	})
+}

--- a/json_unmarshal_test.go
+++ b/json_unmarshal_test.go
@@ -16,6 +16,7 @@ func TestUnmarshal(t *testing.T) {
 		Name      string   `json:"name"`
 		MustFloat *float64 `json:"mustFloat"`
 		MustInt   int      `json:"mustInt"`
+		Uint      uint     `json:"uint"`
 		IsExist   *bool    `json:"isExist"`
 		Obj       *struct {
 			N       int `json:"n"`
@@ -34,6 +35,7 @@ func TestUnmarshal(t *testing.T) {
 				"name": "agungdp",
 				"mustFloat": "2.23423",
 				"mustInt": 2.23423,
+				"uint": 11,
 				"isExist": "true",
 				"obj": {
 				  "n": 2,

--- a/json_unmarshal_test.go
+++ b/json_unmarshal_test.go
@@ -1,12 +1,13 @@
 package goson
 
 import (
+	"fmt"
 	"testing"
 )
 
 func TestUnmarshal(t *testing.T) {
 	type Slice struct {
-		FieldA int     `json:"fieldA"`
+		FieldA uint16  `json:"fieldA"`
 		FieldB string  `json:"fieldB"`
 		Exist  string  `json:"exist"`
 		Test   float32 `json:"test"`
@@ -27,9 +28,10 @@ func TestUnmarshal(t *testing.T) {
 		Slice   []Slice   `json:"slice"`
 		Strings []*string `json:"str"`
 		Ints    []int     `json:"ints"`
+		Bools   []bool    `json:"bools"`
 	}
 
-	t.Run("Testing unmarshal", func(t *testing.T) {
+	t.Run("Testcase #1: Testing Unmarshal with root is JSON Object", func(t *testing.T) {
 		data := []byte(`{
 				"id": "01",
 				"name": "agungdp",
@@ -46,23 +48,29 @@ func TestUnmarshal(t *testing.T) {
 				"slice": [
 				  {
 					"fieldA": "100",
-					"fieldB": "3000",
-					"exist": true
+					"fieldB": 3000,
+					"exist": true,
+					"test": "3.14"
 				  },
 				  {
 					"fieldA": 50000,
 					"fieldB": "123000",
+					"exist": 3000,
 					"test": 1323.123
 				  }
 				],
 				"str": ["a", true],
-				"ints": ["2", 3]
+				"ints": ["2", 3],
+				"bools": [1, "true", "0", true]
 			  }`)
 		var target Model
 		if err := Unmarshal(data, &target); err != nil {
 			t.Errorf("Unmarshal() error = %v", err)
 		}
 		if target.MustFloat == nil {
+			t.Errorf("field should not nil")
+		}
+		if target.Uint != 11 {
 			t.Errorf("field should not nil")
 		}
 		if target.Obj.Testing.Ss != 23840923849284 {
@@ -77,8 +85,39 @@ func TestUnmarshal(t *testing.T) {
 		if target.Ints[0] != 2 {
 			t.Errorf("value not equal")
 		}
+		if target.Bools[2] != false {
+			t.Errorf("value not equal")
+		}
 
-		// fmt.Println("==================================================================")
-		// fmt.Printf("\n%+v\n\n", target)
+		fmt.Printf("%+v\n\n", target)
+	})
+
+	t.Run("Testcase #2: Testing Unmarshal with root is JSON Array", func(t *testing.T) {
+		data := []byte(`[
+			{
+				 "fieldA": 100,
+				 "fieldB": "3000",
+				 "exist": "true",
+				 "test": 3.14
+			},
+			{
+				 "fieldA": 50000,
+				 "fieldB": "123000",
+				 "exist": "3000",
+				 "test": 1323.123
+			}
+	   ]`)
+		var target []Slice
+		if err := Unmarshal(data, &target); err != nil {
+			t.Errorf("Unmarshal() error = %v", err)
+		}
+		if target == nil {
+			t.Errorf("field should not nil")
+		}
+		if len(target) != 2 {
+			t.Errorf("not equal")
+		}
+
+		fmt.Printf("%+v\n\n", target)
 	})
 }

--- a/json_unmarshal_test.go
+++ b/json_unmarshal_test.go
@@ -2,8 +2,6 @@ package goson
 
 import (
 	"testing"
-
-	"github.com/agungdwiprasetyo/go-utils/debug"
 )
 
 func TestUnmarshal(t *testing.T) {
@@ -80,6 +78,5 @@ func TestUnmarshal(t *testing.T) {
 
 		// fmt.Println("==================================================================")
 		// fmt.Printf("\n%+v\n\n", target)
-		debug.PrintJSON(target)
 	})
 }


### PR DESCRIPTION
Avoid error and parse to suitable data type if incompatible data type.
example in json string:
````
{
  "id": 20,
  "float": "2.23423"
}
````

and we have a struct:
````
type Model struct {
	ID       string   `json:"id"`
	Float    float64 `json:"float"`
}
````

if unmarshal json string to `Model` (using `encoding/json`) an error will occur (`json: cannot unmarshal number into Go struct field Model.id of type string`)

In this PR, avoid error is incompatible data type between json string and struct model