### PR TITLE
feat: add json reader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 coverage.txt
+go.sum

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ $ go get github.com/Bhinneka/goson
 #### Todo
 - Add more utility
 
-### Hide specific fields
+## Hide specific fields
 ```go
 package main
 
@@ -93,7 +93,7 @@ func main() {
 }
 ```
 
-### Make Zero Omitempty
+## Make Zero Omitempty
 
 ```go
 // Child type
@@ -201,7 +201,7 @@ example := Bhinnekaners{
 ```
 
 
-### Advance JSON Unmarshal
+## Advance JSON Unmarshal
 
 ```go
 package main
@@ -292,5 +292,85 @@ func main() {
                "exist": ""
           }
      ]
+}
+```
+
+## JSON Reader
+
+```go
+package main
+
+import (
+	"fmt"
+	"github.com/Bhinneka/goson"
+)
+
+var data = []byte(`
+{
+	"id": "0101",
+	"name": "agungdp",
+	"mustFloat": "2.23423",
+	"mustInt": 2.23423,
+	"uint": 11,
+	"isExist": "true",
+	"obj": {
+		"n": 2,
+		"testing": {
+			"ss": "23840923849284"
+		}
+	},
+	"slice": [
+		{
+			"fieldA": "100",
+			"fieldB": 3000,
+			"exist": true,
+			"test": "3.14"
+		},
+		{
+			"fieldA": 50000,
+			"fieldB": "123000",
+			"exist": 3000,
+			"test": 1323.123
+		}
+	],
+	"str": ["a", true],
+	"ints": ["2", 3],
+	"bools": [1, "true", "0", true],
+	"NoTag": 19283091832
+}
+`)
+
+func main() {
+	reader, err := goson.Read(data)
+	if err != nil {
+		panic(err)
+	}
+
+	// get string field
+	str, _ := reader.GetField("slice", "[1]", "fieldA").String()
+	fmt.Printf("%s\n", str) // "50000"
+
+	// get int field
+	i, _ := reader.GetField("obj", "testing", "ss").Int()
+	fmt.Printf("%d\n", i) // 23840923849284
+
+	// get uint field
+	u, _ := reader.GetField("uint").Uint()
+	fmt.Printf("%d\n", u) // 11
+
+	// get float field
+	fl, _ := reader.GetField("slice", "[0]", "test").Float()
+	fmt.Printf("%f\n", fl) // 3.14
+
+	// get bool field
+	b, _ := reader.GetField("isExist").Bool()
+	fmt.Printf("%v\n", b) // true
+
+	// get sub-json field (support object & array field)
+	var m struct {
+		SS string `json:"ss"`
+	}
+	reader.GetField("obj", "testing").SetTo(&m)
+	fmt.Printf("%+v\n", m) // {SS: 23840923849284}
 }
 ```

--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,5 @@
 module github.com/Bhinneka/goson
+
+go 1.12
+
+require github.com/stretchr/testify v1.3.0

--- a/json_omitempty_test.go
+++ b/json_omitempty_test.go
@@ -26,8 +26,9 @@ func TestMakeZeroOmitempty(t *testing.T) {
 			Field1 string `json:"field1,omitempty"`
 			Field2 string `json:"field2"`
 		} `json:"addStruct"`
-		AddChildPtr *Child `json:"child"`
-		Slice       []arr  `json:"slice"`
+		AddChildPtr *Child  `json:"child"`
+		Slice       []arr   `json:"slice"`
+		Nullable    *string `json:"nullable,omitempty"`
 	}
 
 	/*

--- a/json_reader.go
+++ b/json_reader.go
@@ -1,0 +1,68 @@
+package goson
+
+import (
+	"encoding/json"
+)
+
+var (
+	arrayCheck = map[byte]byte{
+		'[': ']',
+	}
+)
+
+// Reader json string
+type Reader interface {
+	GetField(keys ...string) Field
+}
+
+// Field from json reader
+type Field interface {
+	Uint() uint
+	Int() int
+	String() string
+	Float() float64
+	Bool() bool
+	SetTo(target interface{}) error
+}
+
+// Read from json input
+func Read(data []byte) Reader {
+	var tmp interface{}
+	json.Unmarshal(data, &tmp)
+
+	return &reader{
+		data: tmp,
+	}
+}
+
+type reader struct {
+	data interface{}
+}
+
+func (r *reader) GetField(keys ...string) Field {
+	return nil
+}
+
+type field struct {
+	value interface{}
+}
+
+func (f *field) Uint() uint {
+	return 0
+}
+
+func (f *field) Int() int {
+	return 0
+}
+
+func (f *field) Float() float64 {
+	return 0.0
+}
+
+func (f *field) String() string {
+	return ""
+}
+
+func (f *field) SetTo(target interface{}) error {
+	return nil
+}

--- a/json_reader.go
+++ b/json_reader.go
@@ -2,6 +2,10 @@ package goson
 
 import (
 	"encoding/json"
+	"fmt"
+	"reflect"
+	"strconv"
+	"strings"
 )
 
 var (
@@ -17,22 +21,25 @@ type Reader interface {
 
 // Field from json reader
 type Field interface {
-	Uint() uint
-	Int() int
-	String() string
-	Float() float64
-	Bool() bool
+	Uint() (uint, error)
+	Int() (int, error)
+	String() (string, error)
+	Float() (float64, error)
+	Bool() (bool, error)
 	SetTo(target interface{}) error
 }
 
 // Read from json input
-func Read(data []byte) Reader {
+func Read(data []byte) (Reader, error) {
 	var tmp interface{}
-	json.Unmarshal(data, &tmp)
+	err := json.Unmarshal(data, &tmp)
+	if err != nil {
+		return nil, err
+	}
 
 	return &reader{
 		data: tmp,
-	}
+	}, nil
 }
 
 type reader struct {
@@ -40,29 +47,73 @@ type reader struct {
 }
 
 func (r *reader) GetField(keys ...string) Field {
-	return nil
+	var data interface{} = r.data
+	field := new(field)
+	func() {
+		var traces []string
+		defer func() {
+			if r := recover(); r != nil {
+				field.err = fmt.Errorf("key '%s' not found or out of range from JSON data", strings.Join(traces, " => "))
+			}
+		}()
+		for _, k := range keys {
+			traces = append(traces, k)
+			if arrayCheck[k[0]] == k[len(k)-1] {
+				if idx, err := strconv.Atoi(k[1 : len(k)-1]); err == nil {
+					data = data.([]interface{})[idx]
+				}
+				continue
+			}
+			tmp, ok := data.(map[string]interface{})[k]
+			if !ok && tmp == nil {
+				panic("invalid key")
+			}
+			data = tmp
+		}
+	}()
+
+	field.value = data
+	return field
 }
 
 type field struct {
+	err   error
 	value interface{}
 }
 
-func (f *field) Uint() uint {
-	return 0
+func (f *field) set(v reflect.Value) error {
+	if f.err != nil {
+		return f.err
+	}
+	return setValue(v, f.value)
 }
 
-func (f *field) Int() int {
-	return 0
+func (f *field) Uint() (u uint, err error) {
+	err = f.set(reflect.ValueOf(&u))
+	return
 }
 
-func (f *field) Float() float64 {
-	return 0.0
+func (f *field) Int() (i int, err error) {
+	err = f.set(reflect.ValueOf(&i))
+	return
 }
 
-func (f *field) String() string {
-	return ""
+func (f *field) Float() (fl float64, err error) {
+	err = f.set(reflect.ValueOf(&fl))
+	return
 }
 
-func (f *field) SetTo(target interface{}) error {
-	return nil
+func (f *field) String() (s string, err error) {
+	err = f.set(reflect.ValueOf(&s))
+	return
+}
+
+func (f *field) Bool() (b bool, err error) {
+	err = f.set(reflect.ValueOf(&b))
+	return
+}
+
+func (f *field) SetTo(target interface{}) (err error) {
+	err = f.set(reflect.ValueOf(target))
+	return
 }

--- a/json_reader_test.go
+++ b/json_reader_test.go
@@ -58,7 +58,7 @@ func Test_Reader(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, i, 1)
 
-		i, err = reader.GetField("obj", "testing", "ssa").Int()
+		i, err = reader.GetField("name").Int()
 		assert.Error(t, err)
 	})
 
@@ -67,8 +67,9 @@ func Test_Reader(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, fl, 3.14)
 
-		fl, err = reader.GetField("slice", "[0]", "a").Float()
-		assert.Error(t, err)
+		fl, err = reader.GetField("str", "[1]").Float()
+		assert.NoError(t, err)
+		assert.Equal(t, float64(1), fl)
 	})
 
 	t.Run("Testcase #4: Get uint field", func(t *testing.T) {
@@ -76,8 +77,8 @@ func Test_Reader(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, u, uint(11))
 
-		u, err = reader.GetField("slice", "a", "b").Uint()
-		assert.Error(t, err)
+		u, err = reader.GetField("str", "[1]").Uint()
+		assert.NoError(t, err)
 	})
 
 	t.Run("Testcase #5: Get bool field", func(t *testing.T) {
@@ -85,7 +86,7 @@ func Test_Reader(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, b, true)
 
-		b, err = reader.GetField("slice", "a", "b").Bool()
+		b, err = reader.GetField("obj", "a", "b").Bool()
 		assert.Error(t, err)
 	})
 
@@ -99,6 +100,11 @@ func Test_Reader(t *testing.T) {
 		assert.Equal(t, m.SS, "23840923849284")
 
 		err = reader.GetField("slice", "a", "b").SetTo(&m)
+		assert.Error(t, err)
+	})
+
+	t.Run("Testcase #6: Invalid JSON format", func(t *testing.T) {
+		_, err := Read([]byte(`{a:3}`))
 		assert.Error(t, err)
 	})
 }

--- a/json_reader_test.go
+++ b/json_reader_test.go
@@ -1,0 +1,104 @@
+package goson
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_Reader(t *testing.T) {
+	jsonStr := []byte(`{
+		"id": "0101",
+		"name": "agungdp",
+		"mustFloat": "2.23423",
+		"mustInt": 2.23423,
+		"uint": 11,
+		"nullable": null,
+		"isExist": "true",
+		"obj": {
+		  "n": 2,
+		  "testing": {
+			"ss": "23840923849284"
+		  }
+		},
+		"slice": [
+		  {
+			"fieldA": "100",
+			"fieldB": 3000,
+			"exist": true,
+			"test": "3.14"
+		  },
+		  {
+			"fieldA": 50000,
+			"fieldB": "123000",
+			"exist": 3000,
+			"test": 1323.123
+		  }
+		],
+		"str": ["a", true],
+		"ints": ["2", 3],
+		"bools": [1, "true", "0", true],
+		"NoTag": 19283091832
+	  }`)
+
+	reader, err := Read(jsonStr)
+	assert.NoError(t, err)
+
+	t.Run("Testcase #1: Get string field", func(t *testing.T) {
+		str, err := reader.GetField("slice", "[1]", "fieldA").String()
+		assert.NoError(t, err)
+		assert.Equal(t, str, "50000")
+
+		str, err = reader.GetField("slice", "[5]", "fieldA").String()
+		assert.Error(t, err)
+	})
+
+	t.Run("Testcase #2: Get int field", func(t *testing.T) {
+		i, err := reader.GetField("bools", "[3]").Int()
+		assert.NoError(t, err)
+		assert.Equal(t, i, 1)
+
+		i, err = reader.GetField("obj", "testing", "ssa").Int()
+		assert.Error(t, err)
+	})
+
+	t.Run("Testcase #3: Get float field", func(t *testing.T) {
+		fl, err := reader.GetField("slice", "[0]", "test").Float()
+		assert.NoError(t, err)
+		assert.Equal(t, fl, 3.14)
+
+		fl, err = reader.GetField("slice", "[0]", "a").Float()
+		assert.Error(t, err)
+	})
+
+	t.Run("Testcase #4: Get uint field", func(t *testing.T) {
+		u, err := reader.GetField("uint").Uint()
+		assert.NoError(t, err)
+		assert.Equal(t, u, uint(11))
+
+		u, err = reader.GetField("slice", "a", "b").Uint()
+		assert.Error(t, err)
+	})
+
+	t.Run("Testcase #5: Get bool field", func(t *testing.T) {
+		b, err := reader.GetField("isExist").Bool()
+		assert.NoError(t, err)
+		assert.Equal(t, b, true)
+
+		b, err = reader.GetField("slice", "a", "b").Bool()
+		assert.Error(t, err)
+	})
+
+	t.Run("Testcase #6: Set to model", func(t *testing.T) {
+		var m struct {
+			SS string `json:"ss"`
+		}
+
+		err := reader.GetField("obj", "testing").SetTo(&m)
+		assert.NoError(t, err)
+		assert.Equal(t, m.SS, "23840923849284")
+
+		err = reader.GetField("slice", "a", "b").SetTo(&m)
+		assert.Error(t, err)
+	})
+}

--- a/json_unmarshal_test.go
+++ b/json_unmarshal_test.go
@@ -3,6 +3,8 @@ package goson
 import (
 	"fmt"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestUnmarshal(t *testing.T) {
@@ -67,33 +69,17 @@ func TestUnmarshal(t *testing.T) {
 				"NoTag": 19283091832
 			  }`)
 		var target Model
-		if err := Unmarshal(data, &target); err != nil {
-			t.Errorf("Unmarshal() error = %v", err)
-		}
-		if target.MustFloat == nil {
-			t.Errorf("field should not nil")
-		}
-		if target.Uint != 11 {
-			t.Errorf("field should not nil")
-		}
-		if target.Obj.Testing.Ss != 23840923849284 {
-			t.Errorf("value not equal")
-		}
-		if target.Slice[0].Exist != "true" {
-			t.Errorf("value not equal")
-		}
-		if *target.Strings[1] != "true" {
-			t.Errorf("value not equal")
-		}
-		if target.Ints[0] != 2 {
-			t.Errorf("value not equal")
-		}
-		if target.Bools[2] != false {
-			t.Errorf("value not equal")
-		}
-		if target.NoTag != "19283091832" {
-			t.Errorf("value not equal")
-		}
+		err := Unmarshal(data, &target)
+		assert.NoError(t, err)
+
+		assert.NotNil(t, target.MustFloat)
+		assert.Equal(t, uint(11), target.Uint)
+		assert.Equal(t, 23840923849284, target.Obj.Testing.Ss)
+		assert.Equal(t, "true", target.Slice[0].Exist)
+		assert.Equal(t, "true", *target.Strings[1])
+		assert.Equal(t, 2, target.Ints[0])
+		assert.Equal(t, false, target.Bools[2])
+		assert.Equal(t, "19283091832", target.NoTag)
 
 		fmt.Printf("%+v\n\n", target)
 	})
@@ -114,15 +100,11 @@ func TestUnmarshal(t *testing.T) {
 			}
 	   ]`)
 		var target []Slice
-		if err := Unmarshal(data, &target); err != nil {
-			t.Errorf("Unmarshal() error = %v", err)
-		}
-		if target == nil {
-			t.Errorf("field should not nil")
-		}
-		if len(target) != 2 {
-			t.Errorf("not equal")
-		}
+		err := Unmarshal(data, &target)
+		assert.NoError(t, err)
+
+		assert.NotNil(t, target)
+		assert.Len(t, target, 2)
 
 		fmt.Printf("%+v\n\n", target)
 	})
@@ -131,17 +113,13 @@ func TestUnmarshal(t *testing.T) {
 		data := []byte(`{}`)
 		var target Model
 		err := Unmarshal(data, target)
-		if err == nil {
-			t.Errorf("Unmarshal() must error, got nil")
-		}
+		assert.Error(t, err)
 	})
 
 	t.Run("Testcase #4: Testing error unmarshal (invalid json format)", func(t *testing.T) {
 		data := []byte(`{1: satu}`)
 		var target Model
 		err := Unmarshal(data, &target)
-		if err == nil {
-			t.Errorf("Unmarshal() must error, got nil")
-		}
+		assert.Error(t, err)
 	})
 }

--- a/parser.go
+++ b/parser.go
@@ -1,0 +1,110 @@
+package goson
+
+import (
+	"fmt"
+	"reflect"
+	"strconv"
+)
+
+const (
+	missmatchErrorPattern = `parsing value "%v": can't set value type %s to target type %s`
+)
+
+var (
+	// check basic data type (integer, float, string, boolean)
+	uintCheck = map[reflect.Kind]bool{
+		reflect.Uint: true, reflect.Uint8: true, reflect.Uint16: true, reflect.Uint32: true, reflect.Uint64: true,
+	}
+	intCheck = map[reflect.Kind]bool{
+		reflect.Int: true, reflect.Int8: true, reflect.Int16: true, reflect.Int32: true, reflect.Int64: true,
+	}
+	floatCheck = map[reflect.Kind]bool{
+		reflect.Float32: true, reflect.Float64: true,
+	}
+	stringCheck = map[reflect.Kind]bool{
+		reflect.String: true,
+	}
+	boolCheck = map[reflect.Kind]bool{
+		reflect.Bool: true,
+	}
+)
+
+func parseFromString(target reflect.Value, str string) (err error) {
+	targetKind := target.Kind()
+	switch {
+	case stringCheck[targetKind]:
+		target.SetString(str)
+	case intCheck[targetKind]:
+		var val int
+		if val, err = strconv.Atoi(str); err == nil {
+			target.SetInt(int64(val))
+		}
+	case uintCheck[targetKind]:
+		var val int
+		if val, err = strconv.Atoi(str); err == nil {
+			target.SetUint(uint64(val))
+		}
+	case floatCheck[targetKind]:
+		var val float64
+		if val, err = strconv.ParseFloat(str, -1); err == nil {
+			target.SetFloat(val)
+		}
+	case boolCheck[targetKind]:
+		var val bool
+		if val, err = strconv.ParseBool(str); err == nil {
+			target.SetBool(val)
+		}
+	default:
+		err = fmt.Errorf(missmatchErrorPattern, str, "string", targetKind)
+	}
+	return
+}
+
+func parseFromFloat(target reflect.Value, fl float64) (err error) {
+	targetKind := target.Kind()
+	switch {
+	case floatCheck[targetKind]:
+		target.SetFloat(fl)
+	case intCheck[targetKind]:
+		target.SetInt(int64(fl))
+	case uintCheck[targetKind]:
+		target.SetUint(uint64(fl))
+	case stringCheck[targetKind]:
+		target.SetString(strconv.FormatFloat(fl, 'f', -1, 64))
+	case boolCheck[targetKind]:
+		var v bool
+		if v, err = strconv.ParseBool(strconv.FormatFloat(fl, 'f', -1, 64)); err == nil {
+			target.SetBool(v)
+		}
+	default:
+		err = fmt.Errorf(missmatchErrorPattern, fl, "float64", targetKind)
+	}
+	return
+}
+
+func parseFromBool(target reflect.Value, bl bool) (err error) {
+	targetKind := target.Kind()
+	switch {
+	case boolCheck[targetKind]:
+		target.SetBool(bl)
+	case stringCheck[targetKind]:
+		target.SetString(strconv.FormatBool(bl))
+	case uintCheck[targetKind]:
+		target.SetUint(uint64(toInt(bl)))
+	case intCheck[targetKind]:
+		target.SetInt(int64(toInt(bl)))
+	case floatCheck[targetKind]:
+		target.SetFloat(float64(toInt(bl)))
+	default:
+		err = fmt.Errorf(missmatchErrorPattern, bl, "boolean", targetKind)
+	}
+	return
+}
+
+// set if true then int is 1, if false then int is 0
+func toInt(b bool) (i int) {
+	if b {
+		i = 1
+	}
+	return
+}


### PR DESCRIPTION
Add new feature: JSON reader, read from json string and parse it to Go data

example we have a JSON string:
```
{
	"slice": [
		{
		     "fieldA": "100"
		},
		{
		     "fieldA": 50000
		}
	],
	"obj": {
		"id": 2,
		"child": {
		    "name": "example"
		}
	},
        "int": 20
}
```

In this PR, we can access the contents from JSON without creating a struct on Go.
```
reader, _ := goson.Read(jsonString)
result, _ := reader.GetField("slice", "[1]", "fieldA").String()
```
value from **result** is `"50000"`

Or, we can access a pieces from JSON just making a required struct
```
var m struct {
    Name string `json:"name"`
}
reader.GetField("obj", "child").SetTo(&m)
```
value from **m** is `{Name: "example"}`